### PR TITLE
[Feature]: Hide scrollbar indicator

### DIFF
--- a/src/components/auth/AuthPassword.tsx
+++ b/src/components/auth/AuthPassword.tsx
@@ -29,7 +29,7 @@ const AuthPassword: FC<StateProps> = ({
   }, [setAuthPassword]);
 
   return (
-    <div id="auth-password-form" className="custom-scroll">
+    <div id="auth-password-form" className="no-scrollbar">
       <div className="auth-form">
         <MonkeyPassword isPasswordVisible={showPassword} />
         <h1>{lang('Login.Header.Password')}</h1>

--- a/src/components/auth/AuthQrCode.tsx
+++ b/src/components/auth/AuthQrCode.tsx
@@ -145,7 +145,7 @@ const AuthCode: FC<StateProps> = ({
   const isAuthReady = authState === 'authorizationStateWaitQrCode';
 
   return (
-    <div id="auth-qr-form" className="custom-scroll">
+    <div id="auth-qr-form" className="no-scrollbar">
       <div className="auth-form qr">
         <div className="qr-outer">
           <div

--- a/src/components/auth/AuthRegister.tsx
+++ b/src/components/auth/AuthRegister.tsx
@@ -53,7 +53,7 @@ const AuthRegister: FC<StateProps> = ({
   }
 
   return (
-    <div id="auth-registration-form" className="custom-scroll">
+    <div id="auth-registration-form" className="no-scrollbar">
       <div className="auth-form">
         <form action="" method="post" onSubmit={handleSubmit}>
           <AvatarEditable onChange={setCroppedFile} />

--- a/src/components/calls/group/GroupCall.tsx
+++ b/src/components/calls/group/GroupCall.tsx
@@ -323,7 +323,7 @@ const GroupCall: FC<OwnProps & StateProps> = ({
         </Button>
       </div>
 
-      <div className="scrollable custom-scroll">
+      <div className="scrollable no-scrollbar">
         <GroupCallParticipantStreams onDoubleClick={handleStreamsDoubleClick} />
 
         {(!isLandscapeLayout || isSidebarOpen)

--- a/src/components/common/ChatOrUserPicker.tsx
+++ b/src/components/common/ChatOrUserPicker.tsx
@@ -170,7 +170,7 @@ const ChatOrUserPicker: FC<OwnProps> = ({
         </div>
         <InfiniteScroll
           ref={topicContainerRef}
-          className="picker-list custom-scroll"
+          className="picker-list no-scrollbar"
           items={topicIds}
           withAbsolutePositioning
           maxHeight={!topicIds ? 0 : topicIds.length * CHAT_HEIGHT_PX}
@@ -224,7 +224,7 @@ const ChatOrUserPicker: FC<OwnProps> = ({
         {viewportIds?.length ? (
           <InfiniteScroll
             ref={containerRef}
-            className="picker-list custom-scroll"
+            className="picker-list no-scrollbar"
             items={viewportIds}
             onLoadMore={getMore}
             withAbsolutePositioning

--- a/src/components/common/CustomEmojiPicker.tsx
+++ b/src/components/common/CustomEmojiPicker.tsx
@@ -367,8 +367,7 @@ const CustomEmojiPicker: FC<OwnProps & StateProps> = ({
   const listClassName = buildClassName(
     pickerStyles.main,
     pickerStyles.main_customEmoji,
-    'no-selection',
-    IS_TOUCH_ENV ? 'no-scrollbar' : 'custom-scroll',
+    'no-selection no-scrollbar',
   );
 
   return (

--- a/src/components/common/CustomEmojiSetsModal.tsx
+++ b/src/components/common/CustomEmojiSetsModal.tsx
@@ -58,7 +58,7 @@ const CustomEmojiSetsModal: FC<OwnProps & StateProps> = ({
       hasCloseButton
       title={lang('lng_custom_emoji_used_sets')}
     >
-      <div className={buildClassName(styles.sets, 'custom-scroll')} ref={customEmojiModalRef} teactFastList>
+      <div className={buildClassName(styles.sets, 'no-scrollbar')} ref={customEmojiModalRef} teactFastList>
         {renderingCustomEmojiSets?.map((customEmojiSet) => (
           <StickerSetCard
             key={customEmojiSet.id}

--- a/src/components/common/GifButton.tsx
+++ b/src/components/common/GifButton.tsx
@@ -72,7 +72,7 @@ const GifButton: FC<OwnProps> = ({
   const getTriggerElement = useCallback(() => ref.current, []);
 
   const getRootElement = useCallback(
-    () => ref.current!.closest('.custom-scroll, .no-scrollbar'),
+    () => ref.current!.closest('.no-scrollbar, .custom-scroll'),
     [],
   );
 

--- a/src/components/common/Picker.tsx
+++ b/src/components/common/Picker.tsx
@@ -127,7 +127,7 @@ const Picker: FC<OwnProps> = ({
   return (
     <div className="Picker">
       {isSearchable && (
-        <div className="picker-header custom-scroll" dir={lang.isRtl ? 'rtl' : undefined}>
+        <div className="picker-header no-scrollbar" dir={lang.isRtl ? 'rtl' : undefined}>
           {lockedSelectedIds.map((id, i) => (
             <PickerSelectedItem
               chatOrUserId={id}
@@ -159,7 +159,7 @@ const Picker: FC<OwnProps> = ({
 
       {viewportIds?.length ? (
         <InfiniteScroll
-          className="picker-list custom-scroll"
+          className="picker-list no-scrollbar"
           items={viewportIds}
           onLoadMore={getMore}
           noScrollRestore={noScrollRestore}

--- a/src/components/common/StickerSetModal.tsx
+++ b/src/components/common/StickerSetModal.tsx
@@ -208,7 +208,7 @@ const StickerSetModal: FC<OwnProps & StateProps> = ({
     >
       {renderingStickerSet?.stickers ? (
         <>
-          <div ref={containerRef} className="stickers custom-scroll" onScroll={handleContentScroll}>
+          <div ref={containerRef} className="stickers no-scrollbar" onScroll={handleContentScroll}>
             <div className="shared-canvas-container stickers-grid">
               <canvas ref={sharedCanvasRef} className="shared-canvas" />
               {renderingStickerSet.stickers.map((sticker) => (

--- a/src/components/common/code/PreBlock.tsx
+++ b/src/components/common/code/PreBlock.tsx
@@ -21,7 +21,7 @@ const PreBlock: FC<OwnProps> = ({ text, noCopy }) => {
 
   return (
     <pre className={blockClass}>
-      <div className="pre-code custom-scroll-x">{text}</div>
+      <div className="pre-code no-scrollbar">{text}</div>
       <CodeOverlay
         text={text}
         className="code-overlay"

--- a/src/components/left/main/ChatList.tsx
+++ b/src/components/left/main/ChatList.tsx
@@ -175,9 +175,9 @@ const ChatList: FC<OwnProps> = ({
         containerRef.current.scrollTo({ top: HEIGHT_HEADER_FIXED });
         setTimeout(() => {
           firstScroll.current = false;
-        }, 200)
+        }, 200);
       }
-    }, 0)
+    }, 0);
     return viewportIds!.map((id, i) => {
       const isPinned = viewportOffset + i < pinnedCount;
       const offsetTop = archiveHeight + (viewportOffset + i) * CHAT_HEIGHT_PX + HEIGHT_HEADER_FIXED;
@@ -205,17 +205,16 @@ const ChatList: FC<OwnProps> = ({
     const scrollTop = event.currentTarget.scrollTop;
     const scrollPercentRounded = Math.min(
       100,
-      Math.round((scrollTop / HEIGHT_HEADER_FIXED) * 100)
+      Math.round((scrollTop / HEIGHT_HEADER_FIXED) * 100),
     );
     const opacity = 1 - scrollPercentRounded * 0.01;
-    const opacityOffset =
-      scrollTop >= HEIGHT_HEADER_FIXED + 10 || scrollPercentRounded == 100
-        ? 0
-        : opacity;
+    // eslint-disable-next-line eqeqeq
+    const opacityOffset = scrollTop >= HEIGHT_HEADER_FIXED + 10 || scrollPercentRounded == 100 ? 0 : opacity;
 
+    // eslint-disable-next-line eqeqeq
     const translatePixel = scrollTop >= HEIGHT_HEADER_FIXED || scrollPercentRounded == 100 ? 0 : Math.min(
       HEIGHT_HEADER_FIXED,
-      ((100 - scrollPercentRounded) * HEIGHT_HEADER_FIXED) / 100
+      ((100 - scrollPercentRounded) * HEIGHT_HEADER_FIXED) / 100,
     );
     const tabFolderTranslatePixel = translatePixel;
     const currentPropertyInStorage = sessionStorage.getItem(activeChatFolder);
@@ -223,23 +222,23 @@ const ChatList: FC<OwnProps> = ({
       sessionStorage.setItem(
         activeChatFolder,
         JSON.stringify({
-          scrollPercentRounded: scrollPercentRounded,
-          tabFolderTranslatePixel: tabFolderTranslatePixel,
-          opacityOffset: opacityOffset,
-        })
+          scrollPercentRounded,
+          tabFolderTranslatePixel,
+          opacityOffset,
+        }),
       );
     }
-    doc.style.setProperty("--header-translate", `-${scrollPercentRounded}%`);
+    doc.style.setProperty('--header-translate', `-${scrollPercentRounded}%`);
     doc.style.setProperty(
-      "--tab-folder-translate",
-      `${tabFolderTranslatePixel}px`
+      '--tab-folder-translate',
+      `${tabFolderTranslatePixel}px`,
     );
-    doc.style.setProperty("--fi-show-header-opacity", `${opacityOffset}`);
+    doc.style.setProperty('--fi-show-header-opacity', `${opacityOffset}`);
   }
 
   return (
     <InfiniteScroll
-      className={buildClassName('chat-list custom-scroll', isForumPanelOpen && 'forum-panel-open')}
+      className={buildClassName('chat-list no-scrollbar', isForumPanelOpen && 'forum-panel-open')}
       ref={containerRef}
       items={viewportIds}
       itemSelector=".ListItem:not(.chat-item-archive)"

--- a/src/components/left/main/ContactList.tsx
+++ b/src/components/left/main/ContactList.tsx
@@ -68,7 +68,7 @@ const ContactList: FC<OwnProps & StateProps> = ({
   const [viewportIds, getMore] = useInfiniteScroll(undefined, listIds, Boolean(filter));
 
   return (
-    <InfiniteScroll items={viewportIds} onLoadMore={getMore} preloadBackwards={PRELOAD_CONTACT} noScrollRestoreOnTop noScrollRestore className="chat-list custom-scroll">
+    <InfiniteScroll items={viewportIds} onLoadMore={getMore} preloadBackwards={PRELOAD_CONTACT} noScrollRestoreOnTop noScrollRestore className="chat-list no-scrollbar">
       {viewportIds?.length ? (
         viewportIds.map((id) => (
           <ListItem

--- a/src/components/left/main/ForumPanel.tsx
+++ b/src/components/left/main/ForumPanel.tsx
@@ -256,7 +256,7 @@ const ForumPanel: FC<OwnProps & StateProps> = ({
       <div className={styles.notch} />
 
       <InfiniteScroll
-        className="chat-list custom-scroll"
+        className="chat-list no-scrollbar"
         ref={containerRef}
         items={viewportIds}
         preloadBackwards={TOPICS_SLICE}

--- a/src/components/left/main/LeftMainHeader.tsx
+++ b/src/components/left/main/LeftMainHeader.tsx
@@ -131,7 +131,6 @@ const LeftMainHeader: FC<OwnProps & StateProps> = ({
     lang, connectionState, isSyncing, isMessageListOpen, isConnectionStatusMinimized, !areChatsLoaded,
   );
 
-
   const handleLockScreenHotkey = useCallback((e: KeyboardEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -390,7 +389,6 @@ const LeftMainHeader: FC<OwnProps & StateProps> = ({
           focused={isSearchFocused}
           isLoading={isLoading || connectionStatusPosition === 'minimized'}
           spinnerColor={connectionStatusPosition === 'minimized' ? 'gray' : undefined}
-          // spinnerBackgroundColor={connectionStatusPosition === 'minimized' && theme === 'light' ? 'light' : undefined}
           spinnerBackgroundColor={connectionStatusPosition === 'minimized' && theme === 'light' ? 'light' : undefined}
           placeholder={searchInputPlaceholder}
           autoComplete="off"

--- a/src/components/left/newChat/NewChatStep2.tsx
+++ b/src/components/left/newChat/NewChatStep2.tsx
@@ -167,7 +167,7 @@ const NewChatStep2: FC<OwnProps & StateProps > = ({
           <>
             <h3 className="chat-members-heading">{lang('GroupInfo.ParticipantCount', memberIds.length, 'i')}</h3>
 
-            <div className="chat-members-list custom-scroll">
+            <div className="chat-members-list no-scrollbar">
               {memberIds.map((id) => (
                 <ListItem inactive className="chat-item-clickable">
                   <PrivateChatInfo userId={id} />

--- a/src/components/left/search/AudioResults.tsx
+++ b/src/components/left/search/AudioResults.tsx
@@ -115,7 +115,7 @@ const AudioResults: FC<OwnProps & StateProps> = ({
   return (
     <div className="LeftSearch">
       <InfiniteScroll
-        className="search-content documents-list custom-scroll"
+        className="search-content documents-list no-scrollbar"
         items={foundMessages}
         onLoadMore={handleLoadMore}
         noFastList

--- a/src/components/left/search/ChatMessageResults.tsx
+++ b/src/components/left/search/ChatMessageResults.tsx
@@ -116,7 +116,7 @@ const ChatMessageResults: FC<OwnProps & StateProps> = ({
   return (
     <div className="LeftSearch">
       <InfiniteScroll
-        className="search-content custom-scroll chat-list"
+        className="search-content no-scrollbar chat-list"
         items={foundMessages}
         onLoadMore={handleLoadMore}
         noFastList

--- a/src/components/left/search/ChatResults.tsx
+++ b/src/components/left/search/ChatResults.tsx
@@ -193,7 +193,7 @@ const ChatResults: FC<OwnProps & StateProps> = ({
 
   return (
     <InfiniteScroll
-      className="LeftSearch custom-scroll"
+      className="LeftSearch no-scrollbar"
       items={foundMessages}
       onLoadMore={handleLoadMore}
       // To prevent scroll jumps caused by delayed local results rendering

--- a/src/components/left/search/DateSuggest.tsx
+++ b/src/components/left/search/DateSuggest.tsx
@@ -16,7 +16,7 @@ const DateSuggest: FC<OwnProps> = ({
 }) => {
   const suggestions = useMemo(() => getSuggestionsFromDate(searchDate), [searchDate]);
   return (
-    <section className="DateSuggest custom-scroll custom-scroll-x">
+    <section className="DateSuggest no-scrollbar">
       {suggestions.map(({ date, text }) => {
         return (
           <div

--- a/src/components/left/search/FileResults.tsx
+++ b/src/components/left/search/FileResults.tsx
@@ -119,7 +119,7 @@ const FileResults: FC<OwnProps & StateProps> = ({
   return (
     <div ref={containerRef} className="LeftSearch">
       <InfiniteScroll
-        className="search-content documents-list custom-scroll"
+        className="search-content documents-list no-scrollbar"
         items={foundMessages}
         onLoadMore={handleLoadMore}
         noFastList

--- a/src/components/left/search/LinkResults.tsx
+++ b/src/components/left/search/LinkResults.tsx
@@ -116,7 +116,7 @@ const LinkResults: FC<OwnProps & StateProps> = ({
   return (
     <div ref={containerRef} className="LeftSearch">
       <InfiniteScroll
-        className="search-content documents-list custom-scroll"
+        className="search-content documents-list no-scrollbar"
         items={foundMessages}
         onLoadMore={handleLoadMore}
         noFastList

--- a/src/components/left/search/MediaResults.tsx
+++ b/src/components/left/search/MediaResults.tsx
@@ -117,7 +117,7 @@ const MediaResults: FC<OwnProps & StateProps> = ({
   const isMessageList = canRenderContents && foundIds && foundIds.length > 0 && searchQuery;
 
   const classNames = buildClassName(
-    'search-content custom-scroll',
+    'search-content no-scrollbar',
     isMessageList && 'chat-list',
   );
 

--- a/src/components/left/search/RecentContacts.tsx
+++ b/src/components/left/search/RecentContacts.tsx
@@ -72,10 +72,10 @@ const RecentContacts: FC<OwnProps & StateProps> = ({
   const lang = useLang();
 
   return (
-    <div className="RecentContacts custom-scroll">
+    <div className="RecentContacts no-scrollbar">
       {topUserIds && (
         <div className="top-peers-section" dir={lang.isRtl ? 'rtl' : undefined}>
-          <div ref={topUsersRef} className="top-peers no-selection">
+          <div ref={topUsersRef} className="top-peers no-selection no-scrollbar">
             {topUserIds.map((userId) => (
               <div
                 key={userId}

--- a/src/components/left/settings/SettingsActiveSessions.tsx
+++ b/src/components/left/settings/SettingsActiveSessions.tsx
@@ -235,7 +235,7 @@ const SettingsActiveSessions: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div className="settings-content custom-scroll SettingsActiveSessions">
+    <div className="settings-content no-scrollbar SettingsActiveSessions">
       {currentSession && renderCurrentSession(currentSession)}
       {hasOtherSessions && renderOtherSessions(otherSessionHashes)}
       {renderAutoTerminate()}

--- a/src/components/left/settings/SettingsActiveWebsites.tsx
+++ b/src/components/left/settings/SettingsActiveWebsites.tsx
@@ -126,7 +126,7 @@ const SettingsActiveWebsites: FC<OwnProps & StateProps> = ({
   if (!orderedHashes.length) return undefined;
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item">
         <ListItem
           className="destructive mb-0 no-icon"

--- a/src/components/left/settings/SettingsCustomEmoji.tsx
+++ b/src/components/left/settings/SettingsCustomEmoji.tsx
@@ -66,7 +66,7 @@ const SettingsCustomEmoji: FC<OwnProps & StateProps> = ({
   ), [customEmojiSetIds, stickerSetsById]);
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       {customEmojiSets && (
         <div className="settings-item">
           <Checkbox

--- a/src/components/left/settings/SettingsDataStorage.tsx
+++ b/src/components/left/settings/SettingsDataStorage.tsx
@@ -128,7 +128,7 @@ const SettingsDataStorage: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       {renderAutoDownloadBlock(
         lang('AutoDownloadPhotosTitle'),
         'Photo',

--- a/src/components/left/settings/SettingsDoNotTranslate.tsx
+++ b/src/components/left/settings/SettingsDoNotTranslate.tsx
@@ -137,7 +137,7 @@ const SettingsDoNotTranslate: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className={buildClassName(styles.root, 'settings-content custom-scroll')}>
+    <div className={buildClassName(styles.root, 'settings-content no-scrollbar')}>
       <div className={buildClassName(styles.item, 'settings-item')}>
         <InputText
           key="search"
@@ -146,7 +146,7 @@ const SettingsDoNotTranslate: FC<OwnProps & StateProps> = ({
           placeholder={lang('Search')}
           teactExperimentControlled
         />
-        <div className={buildClassName(styles.languages, 'radio-group custom-scroll')}>
+        <div className={buildClassName(styles.languages, 'radio-group no-scrollbar')}>
           {filteredDisplayedOptions.map((option) => (
             <Checkbox
               className={styles.checkbox}

--- a/src/components/left/settings/SettingsEditProfile.tsx
+++ b/src/components/left/settings/SettingsEditProfile.tsx
@@ -207,7 +207,7 @@ const SettingsEditProfile: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="settings-fab-wrapper">
-      <div className="settings-content no-border custom-scroll">
+      <div className="settings-content no-border no-scrollbar">
         <div className="settings-edit-profile settings-item">
           <AvatarEditable
             currentAvatarBlobUrl={currentAvatarBlobUrl}

--- a/src/components/left/settings/SettingsExperimental.tsx
+++ b/src/components/left/settings/SettingsExperimental.tsx
@@ -35,7 +35,7 @@ const SettingsExperimental: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIcon
           tgsUrl={LOCAL_TGS_URLS.Experimental}

--- a/src/components/left/settings/SettingsGeneral.tsx
+++ b/src/components/left/settings/SettingsGeneral.tsx
@@ -116,7 +116,7 @@ const SettingsGeneral: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item pt-3">
         <h4 className="settings-item-header" dir={lang.isRtl ? 'rtl' : undefined}>{lang('SETTINGS')}</h4>
 

--- a/src/components/left/settings/SettingsGeneralBackground.tsx
+++ b/src/components/left/settings/SettingsGeneralBackground.tsx
@@ -120,7 +120,7 @@ const SettingsGeneralBackground: FC<OwnProps & StateProps> = ({
   const isUploading = loadedWallpapers?.[0] && loadedWallpapers[0].slug === UPLOADING_WALLPAPER_SLUG;
 
   return (
-    <div className="SettingsGeneralBackground settings-content custom-scroll">
+    <div className="SettingsGeneralBackground settings-content no-scrollbar">
       <div className="settings-item pt-3">
         <ListItem
           icon="camera-add"

--- a/src/components/left/settings/SettingsGeneralBackgroundColor.tsx
+++ b/src/components/left/settings/SettingsGeneralBackgroundColor.tsx
@@ -201,7 +201,7 @@ const SettingsGeneralBackground: FC<OwnProps & StateProps> = ({
   }, []);
 
   const className = buildClassName(
-    'SettingsGeneralBackgroundColor settings-content custom-scroll',
+    'SettingsGeneralBackgroundColor settings-content no-scrollbar',
     isDragging && 'is-dragging',
   );
 

--- a/src/components/left/settings/SettingsLanguage.tsx
+++ b/src/components/left/settings/SettingsLanguage.tsx
@@ -101,7 +101,7 @@ const SettingsLanguage: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content settings-language custom-scroll">
+    <div className="settings-content settings-language no-scrollbar">
       {IS_TRANSLATION_SUPPORTED && (
         <div className="settings-item">
           <Checkbox

--- a/src/components/left/settings/SettingsMain.tsx
+++ b/src/components/left/settings/SettingsMain.tsx
@@ -63,7 +63,7 @@ const SettingsMain: FC<OwnProps & StateProps> = ({
   }, [lastSyncTime, loadAuthorizations]);
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-main-menu">
         {currentUser && (
           <ProfileInfo

--- a/src/components/left/settings/SettingsNotifications.tsx
+++ b/src/components/left/settings/SettingsNotifications.tsx
@@ -146,7 +146,7 @@ const SettingsNotifications: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item">
         <h4 className="settings-item-header" dir={lang.isRtl ? 'rtl' : undefined}>
           Web notifications

--- a/src/components/left/settings/SettingsPasswordForm.tsx
+++ b/src/components/left/settings/SettingsPasswordForm.tsx
@@ -62,7 +62,7 @@ const SettingsPasswordForm: FC<OwnProps> = ({
   });
 
   return (
-    <div className="settings-content password-form custom-scroll">
+    <div className="settings-content password-form no-scrollbar">
       <div className="settings-content-header no-border">
         <PasswordMonkey isBig isPasswordVisible={shouldShowPassword} />
       </div>

--- a/src/components/left/settings/SettingsPerformance.tsx
+++ b/src/components/left/settings/SettingsPerformance.tsx
@@ -156,7 +156,7 @@ function SettingsPerformance({
   }, []);
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item">
         <h4 className="settings-item-header" dir={lang.isRtl ? 'rtl' : undefined}>
           Animation Level

--- a/src/components/left/settings/SettingsPrivacy.tsx
+++ b/src/components/left/settings/SettingsPrivacy.tsx
@@ -150,7 +150,7 @@ const SettingsPrivacy: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item pt-3">
         <ListItem
           icon="delete-user"

--- a/src/components/left/settings/SettingsPrivacyBlockedUsers.tsx
+++ b/src/components/left/settings/SettingsPrivacyBlockedUsers.tsx
@@ -119,7 +119,7 @@ const SettingsPrivacyBlockedUsers: FC<OwnProps & StateProps> = ({
           </p>
         </div>
 
-        <div className="chat-list custom-scroll">
+        <div className="chat-list no-scrollbar">
           {blockedIds?.length ? (
             <div className="scroll-container">
               {blockedIds!.map((contactId, i) => renderContact(contactId, i, 0))}

--- a/src/components/left/settings/SettingsPrivacyVisibility.tsx
+++ b/src/components/left/settings/SettingsPrivacyVisibility.tsx
@@ -172,7 +172,7 @@ const SettingsPrivacyVisibility: FC<OwnProps & StateProps> = ({
   }, [privacyKey, setPrivacyVisibility]);
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item">
         <h4 className="settings-item-header" dir={lang.isRtl ? 'rtl' : undefined}>{headerText}</h4>
 

--- a/src/components/left/settings/SettingsQuickReaction.tsx
+++ b/src/components/left/settings/SettingsQuickReaction.tsx
@@ -52,7 +52,7 @@ const SettingsQuickReaction: FC<OwnProps & StateProps> = ({
   }, [setDefaultReaction]);
 
   return (
-    <div className="settings-content settings-item custom-scroll settings-quick-reaction">
+    <div className="settings-content settings-item no-scrollbar settings-quick-reaction">
       <RadioGroup
         name="quick-reaction-settings"
         options={options}

--- a/src/components/left/settings/SettingsStickers.tsx
+++ b/src/components/left/settings/SettingsStickers.tsx
@@ -94,7 +94,7 @@ const SettingsStickers: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content custom-scroll">
+    <div className="settings-content no-scrollbar">
       <div className="settings-item">
         <Checkbox
           label={lang('SuggestStickers')}

--- a/src/components/left/settings/folders/SettingsFoldersChatsPicker.tsx
+++ b/src/components/left/settings/folders/SettingsFoldersChatsPicker.tsx
@@ -190,7 +190,7 @@ const SettingsFoldersChatsPicker: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Picker SettingsFoldersChatsPicker">
-      <div className="picker-header custom-scroll">
+      <div className="picker-header no-scrollbar">
         {selectedChatTypes.map(renderSelectedChatType)}
         {selectedIds.map((id, i) => (
           <PickerSelectedItem
@@ -209,7 +209,7 @@ const SettingsFoldersChatsPicker: FC<OwnProps & StateProps> = ({
         />
       </div>
       <InfiniteScroll
-        className="picker-list custom-scroll"
+        className="picker-list no-scrollbar"
         itemSelector=".chat-item"
         items={viewportIds}
         onLoadMore={getMore}

--- a/src/components/left/settings/folders/SettingsFoldersEdit.tsx
+++ b/src/components/left/settings/folders/SettingsFoldersEdit.tsx
@@ -264,7 +264,7 @@ const SettingsFoldersEdit: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="settings-fab-wrapper">
-      <div className="settings-content no-border custom-scroll">
+      <div className="settings-content no-border no-scrollbar">
         <div className="settings-content-header">
           <AnimatedIcon
             size={STICKER_SIZE_FOLDER_SETTINGS}

--- a/src/components/left/settings/folders/SettingsFoldersMain.tsx
+++ b/src/components/left/settings/folders/SettingsFoldersMain.tsx
@@ -190,7 +190,7 @@ const SettingsFoldersMain: FC<OwnProps & StateProps> = ({
   }, [foldersById, isPremium, maxFolders]);
 
   return (
-    <div className="settings-content no-border custom-scroll">
+    <div className="settings-content no-border no-scrollbar">
       <div className="settings-content-header">
         <AnimatedIcon
           size={STICKER_SIZE_FOLDER_SETTINGS}

--- a/src/components/left/settings/folders/SettingsShareChatlist.tsx
+++ b/src/components/left/settings/folders/SettingsShareChatlist.tsx
@@ -144,7 +144,7 @@ const SettingsShareChatlist: FC<OwnProps & StateProps> = ({
   const isDisabled = !chatsCount || isLoading;
 
   return (
-    <div className="settings-content no-border custom-scroll SettingsFoldersChatsPicker">
+    <div className="settings-content no-border no-scrollbar SettingsFoldersChatsPicker">
       <div className="settings-content-header">
         <AnimatedIcon
           size={STICKER_SIZE_FOLDER_SETTINGS}

--- a/src/components/left/settings/passcode/SettingsPasscodeCongratulations.tsx
+++ b/src/components/left/settings/passcode/SettingsPasscodeCongratulations.tsx
@@ -26,7 +26,7 @@ const SettingsPasscodeCongratulations: FC<OwnProps> = ({
   useHistoryBack({ isActive, onBack: onReset });
 
   return (
-    <div className="settings-content local-passcode custom-scroll">
+    <div className="settings-content local-passcode no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIcon
           size={STICKER_SIZE_PASSCODE}

--- a/src/components/left/settings/passcode/SettingsPasscodeEnabled.tsx
+++ b/src/components/left/settings/passcode/SettingsPasscodeEnabled.tsx
@@ -26,7 +26,7 @@ const SettingsPasscodeEnabled: FC<OwnProps> = ({
   useHistoryBack({ isActive, onBack: onReset });
 
   return (
-    <div className="settings-content local-passcode custom-scroll">
+    <div className="settings-content local-passcode no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconWithPreview
           tgsUrl={LOCAL_TGS_URLS.Lock}

--- a/src/components/left/settings/passcode/SettingsPasscodeStart.tsx
+++ b/src/components/left/settings/passcode/SettingsPasscodeStart.tsx
@@ -25,7 +25,7 @@ const SettingsPasscodeStart: FC<OwnProps> = ({
   useHistoryBack({ isActive, onBack: onReset });
 
   return (
-    <div className="settings-content local-passcode custom-scroll">
+    <div className="settings-content local-passcode no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconWithPreview
           tgsUrl={LOCAL_TGS_URLS.Lock}

--- a/src/components/left/settings/twoFa/SettingsTwoFaCongratulations.tsx
+++ b/src/components/left/settings/twoFa/SettingsTwoFaCongratulations.tsx
@@ -32,7 +32,7 @@ const SettingsTwoFaCongratulations: FC<OwnProps> = ({
   });
 
   return (
-    <div className="settings-content two-fa custom-scroll">
+    <div className="settings-content two-fa no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIcon
           size={STICKER_SIZE_TWO_FA}

--- a/src/components/left/settings/twoFa/SettingsTwoFaEmailCode.tsx
+++ b/src/components/left/settings/twoFa/SettingsTwoFaEmailCode.tsx
@@ -80,7 +80,7 @@ const SettingsTwoFaEmailCode: FC<OwnProps & StateProps> = ({
   }, [clearError, codeLength, error, onSubmit]);
 
   return (
-    <div className="settings-content two-fa custom-scroll">
+    <div className="settings-content two-fa no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconFromSticker sticker={animatedEmoji} size={ICON_SIZE} className="settings-content-icon" />
       </div>

--- a/src/components/left/settings/twoFa/SettingsTwoFaEnabled.tsx
+++ b/src/components/left/settings/twoFa/SettingsTwoFaEnabled.tsx
@@ -30,7 +30,7 @@ const SettingsTwoFaEnabled: FC<OwnProps> = ({
   });
 
   return (
-    <div className="settings-content two-fa custom-scroll">
+    <div className="settings-content two-fa no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconWithPreview
           tgsUrl={LOCAL_TGS_URLS.Lock}

--- a/src/components/left/settings/twoFa/SettingsTwoFaSkippableForm.tsx
+++ b/src/components/left/settings/twoFa/SettingsTwoFaSkippableForm.tsx
@@ -101,7 +101,7 @@ const SettingsTwoFaSkippableForm: FC<OwnProps & StateProps> = ({
   });
 
   return (
-    <div className="settings-content two-fa custom-scroll">
+    <div className="settings-content two-fa no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconFromSticker sticker={animatedEmoji} size={ICON_SIZE} className="settings-content-icon" />
       </div>

--- a/src/components/left/settings/twoFa/SettingsTwoFaStart.tsx
+++ b/src/components/left/settings/twoFa/SettingsTwoFaStart.tsx
@@ -27,7 +27,7 @@ const SettingsTwoFaStart: FC<OwnProps> = ({
   });
 
   return (
-    <div className="settings-content two-fa custom-scroll">
+    <div className="settings-content two-fa no-scrollbar">
       <div className="settings-content-header no-border">
         <AnimatedIconWithPreview
           tgsUrl={LOCAL_TGS_URLS.Lock}

--- a/src/components/main/premium/GiftPremiumModal.tsx
+++ b/src/components/main/premium/GiftPremiumModal.tsx
@@ -112,7 +112,7 @@ const GiftPremiumModal: FC<OwnProps & StateProps> = ({
       isOpen={isOpen}
       className={styles.modalDialog}
     >
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <Button
           round
           size="smaller"

--- a/src/components/main/premium/PremiumFeatureModal.tsx
+++ b/src/components/main/premium/PremiumFeatureModal.tsx
@@ -227,7 +227,7 @@ const PremiumFeatureModal: FC<OwnProps> = ({
                 <h2 className={buildClassName(styles.header, isScrolledToTop && styles.noHeaderBorder)}>
                   {lang(PREMIUM_FEATURE_TITLES.double_limits)}
                 </h2>
-                <div className={buildClassName(styles.limitsContent, 'custom-scroll')} onScroll={handleLimitsScroll}>
+                <div className={buildClassName(styles.limitsContent, 'no-scrollbar')} onScroll={handleLimitsScroll}>
                   {LIMITS_ORDER.map((limit, i) => {
                     const defaultLimit = limits?.[limit][0].toString();
                     const premiumLimit = limits?.[limit][1].toString();

--- a/src/components/main/premium/PremiumMainModal.tsx
+++ b/src/components/main/premium/PremiumMainModal.tsx
@@ -238,7 +238,7 @@ const PremiumMainModal: FC<OwnProps & StateProps> = ({
     >
       <Transition name="slide" activeKey={currentSection ? 1 : 0} className={styles.transition}>
         {!currentSection ? (
-          <div className={buildClassName(styles.main, 'custom-scroll')} onScroll={handleScroll}>
+          <div className={buildClassName(styles.main, 'no-scrollbar')} onScroll={handleScroll}>
             <Button
               round
               size="smaller"

--- a/src/components/mediaViewer/MediaViewerFooter.tsx
+++ b/src/components/mediaViewer/MediaViewerFooter.tsx
@@ -70,7 +70,7 @@ const MediaViewerFooter: FC<OwnProps> = ({
     <div className={classNames} onClick={stopEvent}>
       {Boolean(text) && (
         <div className="media-viewer-footer-content" onClick={!isMobile ? onClick : undefined}>
-          <p className={`media-text custom-scroll ${isMultiline ? 'multiline' : ''}`} dir="auto">{text}</p>
+          <p className={`media-text no-scrollbar ${isMultiline ? 'multiline' : ''}`} dir="auto">{text}</p>
         </div>
       )}
     </div>

--- a/src/components/middle/MessageLanguageModal.tsx
+++ b/src/components/middle/MessageLanguageModal.tsx
@@ -104,7 +104,7 @@ const MessageLanguageModal: FC<OwnProps & StateProps> = ({
         placeholder={lang('Search')}
         teactExperimentControlled
       />
-      <div className={buildClassName(styles.languages, 'custom-scroll')}>
+      <div className={buildClassName(styles.languages, 'no-scrollbar')}>
         {filteredDisplayedLanguages.map(({ langCode, originalName, translatedName }) => (
           <ListItem
             key={langCode}

--- a/src/components/middle/MessageList.tsx
+++ b/src/components/middle/MessageList.tsx
@@ -575,7 +575,7 @@ const MessageList: FC<OwnProps & StateProps> = ({
   const isBotInfoEmpty = botInfo && !botInfo.description && !botInfo.gif && !botInfo.photo;
 
   const className = buildClassName(
-    'MessageList custom-scroll',
+    'MessageList no-scrollbar',
     noAvatars && 'no-avatars',
     !canPost && 'no-composer',
     type === 'pinned' && 'type-pinned',

--- a/src/components/middle/ReactorListModal.tsx
+++ b/src/components/middle/ReactorListModal.tsx
@@ -181,7 +181,7 @@ const ReactorListModal: FC<OwnProps & StateProps> = ({
       <div dir={lang.isRtl ? 'rtl' : undefined} className="reactor-list-wrapper">
         {viewportIds?.length ? (
           <InfiniteScroll
-            className="reactor-list custom-scroll"
+            className="reactor-list no-scrollbar"
             items={viewportIds}
             onLoadMore={getMore}
           >

--- a/src/components/middle/composer/AttachmentModal.tsx
+++ b/src/components/middle/composer/AttachmentModal.tsx
@@ -526,7 +526,7 @@ const AttachmentModal: FC<OwnProps & StateProps> = ({
         <div
           className={buildClassName(
             styles.attachments,
-            'custom-scroll',
+            'no-scrollbar',
             isBottomDividerShown && styles.attachmentsBottomPadding,
           )}
           onScroll={handleAttachmentsScroll}

--- a/src/components/middle/composer/BotCommandTooltip.tsx
+++ b/src/components/middle/composer/BotCommandTooltip.tsx
@@ -86,7 +86,7 @@ const BotCommandTooltip: FC<OwnProps> = ({
   }
 
   const className = buildClassName(
-    'BotCommandTooltip composer-tooltip custom-scroll',
+    'BotCommandTooltip composer-tooltip no-scrollbar',
     transitionClassNames,
   );
 

--- a/src/components/middle/composer/CustomEmojiTooltip.tsx
+++ b/src/components/middle/composer/CustomEmojiTooltip.tsx
@@ -76,7 +76,7 @@ const CustomEmojiTooltip: FC<OwnProps & StateProps> = ({
 
   const className = buildClassName(
     styles.root,
-    'composer-tooltip custom-scroll-x',
+    'composer-tooltip no-scrollbar',
     transitionClassNames,
     !displayedStickers?.length && styles.hidden,
   );

--- a/src/components/middle/composer/EmojiPicker.tsx
+++ b/src/components/middle/composer/EmojiPicker.tsx
@@ -223,7 +223,7 @@ const EmojiPicker: FC<OwnProps & StateProps> = ({
       <div
         ref={containerRef}
         onScroll={handleContentScroll}
-        className={buildClassName('EmojiPicker-main no-selection', IS_TOUCH_ENV ? 'no-scrollbar' : 'custom-scroll')}
+        className={buildClassName('EmojiPicker-main no-selection', 'no-scrollbar')}
       >
         {allCategories.map((category, i) => (
           <EmojiCategory

--- a/src/components/middle/composer/EmojiTooltip.tsx
+++ b/src/components/middle/composer/EmojiTooltip.tsx
@@ -136,7 +136,7 @@ const EmojiTooltip: FC<OwnProps> = ({
   }, [selectedIndex]);
 
   const className = buildClassName(
-    'EmojiTooltip composer-tooltip custom-scroll-x',
+    'EmojiTooltip composer-tooltip no-scrollbar',
     transitionClassNames,
   );
 

--- a/src/components/middle/composer/GifPicker.tsx
+++ b/src/components/middle/composer/GifPicker.tsx
@@ -66,7 +66,7 @@ const GifPicker: FC<OwnProps & StateProps> = ({
     <div>
       <div
         ref={containerRef}
-        className={buildClassName('GifPicker', className, IS_TOUCH_ENV ? 'no-scrollbar' : 'custom-scroll')}
+        className={buildClassName('GifPicker', className, 'no-scrollbar')}
       >
         {!canSendGifs ? (
           <div className="picker-disabled">Sending GIFs is not allowed in this chat.</div>

--- a/src/components/middle/composer/InlineBotTooltip.tsx
+++ b/src/components/middle/composer/InlineBotTooltip.tsx
@@ -131,7 +131,7 @@ const InlineBotTooltip: FC<OwnProps> = ({
 
   const className = buildClassName(
     'InlineBotTooltip composer-tooltip',
-    IS_TOUCH_ENV ? 'no-scrollbar' : 'custom-scroll',
+    'no-scrollbar',
     renderedIsGallery && 'gallery',
     transitionClassNames,
   );

--- a/src/components/middle/composer/MentionTooltip.tsx
+++ b/src/components/middle/composer/MentionTooltip.tsx
@@ -89,7 +89,7 @@ const MentionTooltip: FC<OwnProps> = ({
   }
 
   const className = buildClassName(
-    'MentionTooltip composer-tooltip custom-scroll',
+    'MentionTooltip composer-tooltip no-scrollbar',
     transitionClassNames,
   );
 

--- a/src/components/middle/composer/MessageInput.tsx
+++ b/src/components/middle/composer/MessageInput.tsx
@@ -527,7 +527,7 @@ const MessageInput: FC<OwnProps & StateProps> = ({
   return (
     <div id={id} onClick={shouldSuppressFocus ? onSuppressedFocus : undefined} dir={lang.isRtl ? 'rtl' : undefined}>
       <div
-        className={buildClassName('custom-scroll', SCROLLER_CLASS)}
+        className={buildClassName('no-scrollbar', SCROLLER_CLASS)}
         onScroll={onScroll}
         onClick={!isAttachmentModalInput && !canSendPlainText ? handleClick : undefined}
       >
@@ -566,7 +566,7 @@ const MessageInput: FC<OwnProps & StateProps> = ({
           <div ref={absoluteContainerRef} className="absolute-video-container" />
         </div>
       </div>
-      <div ref={scrollerCloneRef} className={buildClassName('custom-scroll', SCROLLER_CLASS, 'clone')}>
+      <div ref={scrollerCloneRef} className={buildClassName('no-scrollbar', SCROLLER_CLASS, 'clone')}>
         <div className="input-scroller-content">
           <div ref={cloneRef} className={buildClassName(className, 'clone')} dir="auto" />
         </div>

--- a/src/components/middle/composer/PollModal.tsx
+++ b/src/components/middle/composer/PollModal.tsx
@@ -316,7 +316,7 @@ const PollModal: FC<OwnProps> = ({
       />
       <div className="options-divider" />
 
-      <div className="options-list custom-scroll" ref={optionsListRef}>
+      <div className="options-list no-scrollbar" ref={optionsListRef}>
         <h3 className="options-header">{lang('PollOptions')}</h3>
 
         {hasErrors && renderQuizNoOptionError()}

--- a/src/components/middle/composer/StickerPicker.tsx
+++ b/src/components/middle/composer/StickerPicker.tsx
@@ -347,7 +347,7 @@ const StickerPicker: FC<OwnProps & StateProps> = ({
         ref={containerRef}
         onMouseMove={handleMouseMove}
         onScroll={handleContentScroll}
-        className={buildClassName(styles.main, 'no-selection', IS_TOUCH_ENV ? 'no-scrollbar' : 'custom-scroll')}
+        className={buildClassName(styles.main, 'no-selection', 'no-scrollbar')}
       >
         {allSets.map((stickerSet, i) => (
           <StickerSet

--- a/src/components/middle/composer/StickerTooltip.tsx
+++ b/src/components/middle/composer/StickerTooltip.tsx
@@ -62,7 +62,7 @@ const StickerTooltip: FC<OwnProps & StateProps> = ({
   };
 
   const className = buildClassName(
-    'StickerTooltip composer-tooltip custom-scroll',
+    'StickerTooltip composer-tooltip no-scrollbar',
     transitionClassNames,
     !(displayedStickers?.length) && 'hidden',
   );

--- a/src/components/middle/message/MessageContextMenu.tsx
+++ b/src/components/middle/message/MessageContextMenu.tsx
@@ -339,7 +339,7 @@ const MessageContextMenu: FC<OwnProps> = ({
 
       <div
         className={buildClassName(
-          'MessageContextMenu_items scrollable-content custom-scroll',
+          'MessageContextMenu_items scrollable-content no-scrollbar',
           areItemsHidden && 'MessageContextMenu_items-hidden',
         )}
         style={menuStyle}

--- a/src/components/middle/message/ReactionPickerLimited.tsx
+++ b/src/components/middle/message/ReactionPickerLimited.tsx
@@ -82,7 +82,7 @@ const ReactionPickerLimited: FC<OwnProps & StateProps> = ({
 
   return (
     <div className={styles.root} style={`height: ${pickerHeight}px`}>
-      <div className={buildClassName(styles.wrapper, 'no-selection', isTouchScreen ? 'no-scrollbar' : 'custom-scroll')}>
+      <div className={buildClassName(styles.wrapper, 'no-selection', 'no-scrollbar')}>
         <div className="symbol-set-container shared-canvas-container">
           <canvas ref={sharedCanvasRef} className="shared-canvas" />
           <canvas ref={sharedCanvasHqRef} className="shared-canvas" />

--- a/src/components/modals/chatlist/ChatlistAlready.tsx
+++ b/src/components/modals/chatlist/ChatlistAlready.tsx
@@ -56,7 +56,7 @@ const ChatlistAlready: FC<OwnProps> = ({ invite, folder }) => {
       <div className={styles.description}>
         {renderText(descriptionText, ['simple_markdown', 'emoji'])}
       </div>
-      <div className={buildClassName(styles.pickerWrapper, 'custom-scroll')}>
+      <div className={buildClassName(styles.pickerWrapper, 'no-scrollbar')}>
         {Boolean(invite.missingPeerIds.length) && (
           <>
             <div className={styles.pickerHeader}>

--- a/src/components/modals/chatlist/ChatlistDelete.tsx
+++ b/src/components/modals/chatlist/ChatlistDelete.tsx
@@ -50,7 +50,7 @@ const ChatlistDelete: FC<OwnProps> = ({
           <div className={styles.description}>
             {renderText(lang('FolderLinkSubtitleRemove'), ['simple_markdown', 'emoji'])}
           </div>
-          <div className={buildClassName(styles.pickerWrapper, 'custom-scroll')}>
+          <div className={buildClassName(styles.pickerWrapper, 'no-scrollbar')}>
             <div className={styles.pickerHeader}>
               <div className={styles.pickerHeaderInfo}>
                 {lang('FolderLinkHeaderChatsQuit', selectedPeerIds.length, 'i')}

--- a/src/components/modals/chatlist/ChatlistNew.tsx
+++ b/src/components/modals/chatlist/ChatlistNew.tsx
@@ -55,7 +55,7 @@ const ChatlistNew: FC<OwnProps> = ({ invite }) => {
       <div className={styles.description}>
         {renderText(lang('FolderLinkSubtitle', invite.title), ['simple_markdown', 'emoji'])}
       </div>
-      <div className={buildClassName(styles.pickerWrapper, 'custom-scroll')}>
+      <div className={buildClassName(styles.pickerWrapper, 'no-scrollbar')}>
         <div className={styles.pickerHeader}>
           <div className={styles.pickerHeaderInfo}>
             {lang('FolderLinkHeaderChatsJoin', selectedCount, 'i')}

--- a/src/components/payment/PaymentModal.tsx
+++ b/src/components/payment/PaymentModal.tsx
@@ -559,7 +559,7 @@ const PaymentModal: FC<OwnProps & StateProps & GlobalStateProps> = ({
       </div>
       {step !== undefined ? (
         <Transition name="slide" activeKey={step}>
-          <div className="content custom-scroll">
+          <div className="content no-scrollbar">
             {renderModalContent(step)}
           </div>
         </Transition>

--- a/src/components/payment/ReceiptModal.tsx
+++ b/src/components/payment/ReceiptModal.tsx
@@ -99,7 +99,7 @@ const ReceiptModal: FC<OwnProps & StateProps> = ({
           </Button>
           <h3> {lang('PaymentReceipt')} </h3>
         </div>
-        <div className="receipt-content custom-scroll">
+        <div className="receipt-content no-scrollbar">
           <Checkout
             prices={prices}
             shippingPrices={shippingPrices}

--- a/src/components/right/CreateTopic.tsx
+++ b/src/components/right/CreateTopic.tsx
@@ -106,7 +106,7 @@ const CreateTopic: FC<OwnProps & StateProps> = ({
 
   return (
     <div className={styles.root}>
-      <div className={buildClassName(styles.content, 'custom-scroll')}>
+      <div className={buildClassName(styles.content, 'no-scrollbar')}>
         <div className={buildClassName(styles.section, styles.top)}>
           <span className={styles.heading}>{lang('CreateTopicTitle')}</span>
           <Transition

--- a/src/components/right/EditTopic.tsx
+++ b/src/components/right/EditTopic.tsx
@@ -114,7 +114,7 @@ const EditTopic: FC<OwnProps & StateProps> = ({
 
   return (
     <div className={styles.root}>
-      <div className={buildClassName(styles.content, 'custom-scroll')}>
+      <div className={buildClassName(styles.content, 'no-scrollbar')}>
         {!topic && <Loading />}
         {topic && (
           <>

--- a/src/components/right/GifSearch.tsx
+++ b/src/components/right/GifSearch.tsx
@@ -133,7 +133,7 @@ const GifSearch: FC<OwnProps & StateProps> = ({
     <div className="GifSearch" dir={lang.isRtl ? 'rtl' : undefined}>
       <InfiniteScroll
         ref={containerRef}
-        className={buildClassName('gif-container custom-scroll', hasResults && 'grid')}
+        className={buildClassName('gif-container no-scrollbar', hasResults && 'grid')}
         items={results}
         itemSelector=".GifButton"
         preloadBackwards={PRELOAD_BACKWARDS}

--- a/src/components/right/PollResults.tsx
+++ b/src/components/right/PollResults.tsx
@@ -53,7 +53,7 @@ const PollResults: FC<OwnProps & StateProps> = ({
   return (
     <div className="PollResults" dir={lang.isRtl ? 'rtl' : undefined}>
       <h3 className="poll-question" dir="auto">{renderText(summary.question, ['emoji', 'br'])}</h3>
-      <div className="poll-results-list custom-scroll">
+      <div className="poll-results-list no-scrollbar">
         {Boolean(lastSyncTime) && summary.answers.map((answer) => (
           <PollAnswerResults
             key={`${message.id}-${answer.option}`}

--- a/src/components/right/Profile.tsx
+++ b/src/components/right/Profile.tsx
@@ -454,7 +454,7 @@ const Profile: FC<OwnProps & StateProps> = ({
   return (
     <InfiniteScroll
       ref={containerRef}
-      className="Profile custom-scroll"
+      className="Profile no-scrollbar"
       itemSelector={`.shared-media-transition > .Transition_slide-active.${resultType}-list > .scroll-item`}
       items={canRenderContent ? viewportIds : undefined}
       cacheBuster={cacheBuster}

--- a/src/components/right/RightSearch.tsx
+++ b/src/components/right/RightSearch.tsx
@@ -163,7 +163,7 @@ const RightSearch: FC<OwnProps & StateProps> = ({
   return (
     <InfiniteScroll
       ref={containerRef}
-      className="RightSearch custom-scroll"
+      className="RightSearch no-scrollbar"
       items={viewportResults}
       preloadBackwards={0}
       onLoadMore={getMore}

--- a/src/components/right/StickerSearch.tsx
+++ b/src/components/right/StickerSearch.tsx
@@ -98,7 +98,7 @@ const StickerSearch: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div ref={containerRef} className="StickerSearch custom-scroll" dir={lang.isRtl ? 'rtl' : undefined}>
+    <div ref={containerRef} className="StickerSearch no-scrollbar" dir={lang.isRtl ? 'rtl' : undefined}>
       {renderContent()}
     </div>
   );

--- a/src/components/right/management/ManageChannel.tsx
+++ b/src/components/right/management/ManageChannel.tsx
@@ -221,7 +221,7 @@ const ManageChannel: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <AvatarEditable
             currentAvatarBlobUrl={currentAvatarBlobUrl}

--- a/src/components/right/management/ManageChatAdministrators.tsx
+++ b/src/components/right/management/ManageChatAdministrators.tsx
@@ -91,7 +91,7 @@ const ManageChatAdministrators: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <ListItem
             icon="recent"

--- a/src/components/right/management/ManageChatPrivacyType.tsx
+++ b/src/components/right/management/ManageChatPrivacyType.tsx
@@ -189,7 +189,7 @@ const ManageChatPrivacyType: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section" dir={lang.isRtl ? 'rtl' : undefined}>
           <h3 className="section-heading">{lang(`${langPrefix2}Type`)}</h3>
           <RadioGroup

--- a/src/components/right/management/ManageChatRemovedUsers.tsx
+++ b/src/components/right/management/ManageChatRemovedUsers.tsx
@@ -81,7 +81,7 @@ const ManageChatRemovedUsers: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section" dir={lang.isRtl ? 'rtl' : undefined}>
           <p className="text-muted">{lang(isChannel ? 'NoBlockedChannel2' : 'NoBlockedGroup2')}</p>
 

--- a/src/components/right/management/ManageDiscussion.tsx
+++ b/src/components/right/management/ManageDiscussion.tsx
@@ -245,7 +245,7 @@ const ManageDiscussion: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <AnimatedIcon
             tgsUrl={LOCAL_TGS_URLS.DiscussionGroups}

--- a/src/components/right/management/ManageGroup.tsx
+++ b/src/components/right/management/ManageGroup.tsx
@@ -323,7 +323,7 @@ const ManageGroup: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <AvatarEditable
             isForForum={isForumEnabled}

--- a/src/components/right/management/ManageGroupAdminRights.tsx
+++ b/src/components/right/management/ManageGroupAdminRights.tsx
@@ -203,7 +203,7 @@ const ManageGroupAdminRights: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <ListItem inactive className="chat-item-clickable">
             <PrivateChatInfo

--- a/src/components/right/management/ManageGroupMembers.tsx
+++ b/src/components/right/management/ManageGroupMembers.tsx
@@ -191,7 +191,7 @@ const ManageGroupMembers: FC<OwnProps & StateProps> = ({
   return (
     <div className="Management">
       {noAdmins && renderSearchField()}
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         {canHideParticipants && (
           <div className="section">
             <ListItem icon="group" ripple onClick={handleToggleParticipantsHidden}>
@@ -206,7 +206,7 @@ const ManageGroupMembers: FC<OwnProps & StateProps> = ({
         <div className="section">
           {viewportIds?.length ? (
             <InfiniteScroll
-              className="picker-list custom-scroll"
+              className="picker-list no-scrollbar"
               items={displayedIds}
               onLoadMore={getMore}
               noScrollRestore={Boolean(searchQuery)}

--- a/src/components/right/management/ManageGroupPermissions.tsx
+++ b/src/components/right/management/ManageGroupPermissions.tsx
@@ -182,7 +182,7 @@ const ManageGroupPermissions: FC<OwnProps & StateProps> = ({
       style={`--shift-height: ${ITEMS_COUNT * ITEM_HEIGHT}px;`
         + `--before-shift-height: ${BEFORE_ITEMS_COUNT * ITEM_HEIGHT}px;`}
     >
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section without-bottom-shadow">
           <h3 className="section-heading" dir="auto">{lang('ChannelPermissionsHeader')}</h3>
 

--- a/src/components/right/management/ManageGroupUserPermissions.tsx
+++ b/src/components/right/management/ManageGroupUserPermissions.tsx
@@ -138,7 +138,7 @@ const ManageGroupUserPermissions: FC<OwnProps & StateProps> = ({
       style={`--shift-height: ${ITEMS_COUNT * ITEM_HEIGHT - SHIFT_HEIGHT_MINUS}px;`
            + `--before-shift-height: ${BEFORE_ITEMS_COUNT * ITEM_HEIGHT + BEFORE_USER_INFO_HEIGHT}px;`}
     >
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section without-bottom-shadow">
           <ListItem inactive className="chat-item-clickable">
             <PrivateChatInfo userId={selectedChatMember.userId} forceShowSelf />

--- a/src/components/right/management/ManageGroupUserPermissionsCreate.tsx
+++ b/src/components/right/management/ManageGroupUserPermissionsCreate.tsx
@@ -62,7 +62,7 @@ const ManageGroupUserPermissionsCreate: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section" teactFastList>
           {memberIds ? (
             memberIds.map((id, i) => (

--- a/src/components/right/management/ManageInvite.tsx
+++ b/src/components/right/management/ManageInvite.tsx
@@ -156,7 +156,7 @@ const ManageInvite: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management ManageInvite">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <Checkbox
             label={lang('ApproveNewMembers')}

--- a/src/components/right/management/ManageInviteInfo.tsx
+++ b/src/components/right/management/ManageInviteInfo.tsx
@@ -135,7 +135,7 @@ const ManageInviteInfo: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management ManageInviteInfo">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         {!invite && (
           <p className="text-muted">{lang('Loading')}</p>
         )}

--- a/src/components/right/management/ManageInvites.tsx
+++ b/src/components/right/management/ManageInvites.tsx
@@ -272,7 +272,7 @@ const ManageInvites: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management ManageInvites">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <AnimatedIcon
             tgsUrl={LOCAL_TGS_URLS.Invite}

--- a/src/components/right/management/ManageJoinRequests.tsx
+++ b/src/components/right/management/ManageJoinRequests.tsx
@@ -65,7 +65,7 @@ const ManageJoinRequests: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management ManageJoinRequests">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <AnimatedIcon
             tgsUrl={LOCAL_TGS_URLS.JoinRequest}

--- a/src/components/right/management/ManageReactions.tsx
+++ b/src/components/right/management/ManageReactions.tsx
@@ -119,7 +119,7 @@ const ManageReactions: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <h3 className="section-heading">
             {lang('AvailableReactions')}

--- a/src/components/right/management/ManageUser.tsx
+++ b/src/components/right/management/ManageUser.tsx
@@ -183,7 +183,7 @@ const ManageUser: FC<OwnProps & StateProps> = ({
 
   return (
     <div className="Management">
-      <div className="custom-scroll">
+      <div className="no-scrollbar">
         <div className="section">
           <PrivateChatInfo
             userId={user.id}

--- a/src/components/right/management/Management.scss
+++ b/src/components/right/management/Management.scss
@@ -5,8 +5,7 @@
 
   & > .custom-scroll {
     height: 100%;
-    overflow-y: scroll;
-    overflow-x: hidden;
+    overflow: hidden;
   }
 
   .personal-photo {

--- a/src/components/right/management/Management.scss
+++ b/src/components/right/management/Management.scss
@@ -5,7 +5,8 @@
 
   & > .custom-scroll {
     height: 100%;
-    overflow: hidden;
+    overflow-y: scroll;
+    overflow-x: hidden;
   }
 
   .personal-photo {

--- a/src/components/right/statistics/MessageStatistics.tsx
+++ b/src/components/right/statistics/MessageStatistics.tsx
@@ -147,7 +147,7 @@ const Statistics: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div className={buildClassName('Statistics custom-scroll', isReady && 'ready')}>
+    <div className={buildClassName('Statistics no-scrollbar', isReady && 'ready')}>
       <StatisticsOverview statistics={statistics} isMessage />
 
       {!loadedCharts.current.length && <Loading />}

--- a/src/components/right/statistics/Statistics.tsx
+++ b/src/components/right/statistics/Statistics.tsx
@@ -175,7 +175,7 @@ const Statistics: FC<OwnProps & StateProps> = ({
   }
 
   return (
-    <div className={buildClassName('Statistics custom-scroll', isReady && 'ready')}>
+    <div className={buildClassName('Statistics no-scrollbar', isReady && 'ready')}>
       <StatisticsOverview statistics={statistics} isGroup={isGroup} />
 
       {!loadedCharts.current.length && <Loading />}

--- a/src/components/ui/ListItem.tsx
+++ b/src/components/ui/ListItem.tsx
@@ -111,7 +111,7 @@ const ListItem: FC<OwnProps> = ({
   const getTriggerElement = useCallback(() => containerRef.current, []);
 
   const getRootElement = useCallback(
-    () => containerRef.current!.closest('.custom-scroll'),
+    () => containerRef.current!.closest('.no-scrollbar'),
     [],
   );
 

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -125,7 +125,7 @@ const Menu: FC<OwnProps> = ({
   );
 
   const bubbleFullClassName = buildClassName(
-    'bubble menu-container custom-scroll',
+    'bubble menu-container no-scrollbar',
     positionY,
     positionX,
     footer && 'with-footer',

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -163,7 +163,7 @@ const Modal: FC<OwnProps & StateProps> = ({
           <div className="modal-backdrop" onClick={!noBackdropClose ? onClose : undefined} />
           <div className="modal-dialog" ref={dialogRef}>
             {renderHeader()}
-            <div className="modal-content custom-scroll" style={style}>
+            <div className="modal-content no-scrollbar" style={style}>
               {children}
             </div>
           </div>

--- a/src/util/highlightCode.ts
+++ b/src/util/highlightCode.ts
@@ -119,7 +119,7 @@ function treeToElements(tree: Element | Root): TeactNode {
   }).filter(Boolean);
 
   if (tree.type === 'root') {
-    return Teact.createElement('code', { className: 'hljs custom-scroll-x' }, children) as unknown as TeactNode;
+    return Teact.createElement('code', { className: 'hljs no-scrollbar' }, children) as unknown as TeactNode;
   }
 
   const name = tree.tagName;


### PR DESCRIPTION
- Hide scroll bar indicator by replace className "custom-scroll" by "no-scrollbar". 
- These css styles are not cause break layout because it has just only changed scrollbar width.