### PR TITLE
[Feature]: Hide scrollbar indicator

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -144,42 +144,23 @@ body.cursor-ew-resize {
 
 .custom-scroll,
 .custom-scroll-x {
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-  transition: scrollbar-color 0.3s ease;
+  scrollbar-width: none;
 
-  -webkit-overflow-scrolling: touch;
-  // Fix scroll lock on iOS
-  pointer-events: auto;
-
-  &::-webkit-scrollbar-thumb {
-    background-color: transparent;
-    border-radius: 0.375rem;
-    // `box-shadow` prevents repaint on macOS when hovering out of scrollable container
-    box-shadow: 0 0 1px rgba(255, 255, 255, 0.01);
-  }
-
-  &:hover,
-  &:focus,
-  &:focus-within {
-    scrollbar-color: var(--color-scrollbar) transparent;
-
-    &::-webkit-scrollbar-thumb {
-      background-color: var(--color-scrollbar);
-    }
+  &::-webkit-scrollbar {
+    display: none;
   }
 }
 
 body:not(.is-ios) {
   .custom-scroll {
     &::-webkit-scrollbar {
-      width: 0.375rem;
+      display: none;
     }
   }
 
   .custom-scroll-x {
     &::-webkit-scrollbar {
-      height: 0.375rem;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
- Hide scroll bar indicator by replace className "custom-scroll" by "no-scrollbar".
- These css styles are not cause break layout because it has just only changed scrollbar width.