### PR TITLE
[BugFix]: Remove move to main menu option

### DIFF
--- a/src/components/left/main/Archive.tsx
+++ b/src/components/left/main/Archive.tsx
@@ -81,15 +81,15 @@ const Archive: FC<OwnProps> = ({
       },
     };
 
-    const actionHide = {
-      title: lang('lng_context_archive_to_menu'),
-      icon: 'archive-to-main',
-      handler: () => {
-        updateArchiveSettings({ isHidden: true });
-      },
-    };
+    // const actionHide = {
+    //   title: lang('lng_context_archive_to_menu'),
+    //   icon: 'archive-to-main',
+    //   handler: () => {
+    //     updateArchiveSettings({ isHidden: true });
+    //   },
+    // };
 
-    return compact([actionMinimize, actionExpand, actionHide]);
+    return compact([actionMinimize, actionExpand]);
   }, [archiveSettings.isMinimized, lang, updateArchiveSettings]);
 
   const handleDragEnter = useCallback((e) => {


### PR DESCRIPTION
- Remove "Move to main menu" option when right click at Archive. Because the App hide setting button, so we can't select "Main menu" to restore Archive.